### PR TITLE
Some glue code changes

### DIFF
--- a/client/src/Player.lua
+++ b/client/src/Player.lua
@@ -97,36 +97,7 @@ function Player:createStackFromSettings(match, which)
   self.stack = Stack(args)
   -- so the stack can draw player information
   self.stack.player = self
-  self.stack.battleAnimations = {}
-  for name, set in pairs(characters[self.stack.character].battleAnimations) do
-    local anim = set:clone()
-    anim:stop()
-    anim:setSwitchFunction(
-      function (s, state)
-        local switch
-        local finish = false
-        if self.stack.match.ended then
-          switch = (self.stack.game_over_clock <= 0 and "win") or "lose"
-        elseif state == "hurt" or self.stack.shake_time > 0 then
-          switch = "hurt"
-        elseif state == "attack" then
-          switch = "attack"
-        elseif (self.stack.danger)then
-          switch = "danger"
-          finish = anim.currentAnim ~= "normal"
-        else
-          switch = "normal"
-          finish = true
-        end
-        if anim.animations[switch] ~= nil then
-          s:switchAnimation(switch, finish)
-        end
-      end
-    )
-    self.stack.battleAnimations[name] = anim
-    self.stack:connectSignal("hurt", self.stack.battleAnimations[name], self.stack.battleAnimations[name].switchFunction)
-    self.stack:connectSignal("attackSent", self.stack.battleAnimations[name], self.stack.battleAnimations[name].switchFunction)
-  end
+
   return self.stack
 end
 

--- a/client/src/graphics/Stack.lua
+++ b/client/src/graphics/Stack.lua
@@ -997,3 +997,12 @@ function Stack:drawPanels(garbageImages, shockGarbageImages, shakeOffset)
   panelSet:drawBatch()
   prof.pop("Stack:drawPanels")
 end
+
+function Stack:initializeGraphics()
+  self.multi_prestopQuad = GraphicsUtil:newRecycledQuad(0, 0, self.theme.images.IMG_multibar_prestop_bar:getDimensions())
+  self.multi_stopQuad = GraphicsUtil:newRecycledQuad(0, 0, self.theme.images.IMG_multibar_stop_bar:getDimensions())
+  self.multi_shakeQuad = GraphicsUtil:newRecycledQuad(0, 0, self.theme.images.IMG_multibar_shake_bar:getDimensions())
+  self.multiBarFrameCount = self:calculateMultibarFrameCount()
+
+  characters[self.character]:initializeStackAnimation(self)
+end

--- a/client/src/graphics/graphics_util.lua
+++ b/client/src/graphics/graphics_util.lua
@@ -143,11 +143,11 @@ local maxQuadPool = 100
 function GraphicsUtil:newRecycledQuad(x, y, width, height, sw, sh)
   local result = nil
   if #self.quadPool == 0 then
-    result = love.graphics.newQuad(x, y, width, height, sw, sh)
+    result = love.graphics.newQuad(x, y, width, height, sw or width, sh or height)
   else
     result = self.quadPool[#self.quadPool]
     self.quadPool[#self.quadPool] = nil
-    result:setViewport(x, y, width, height, sw, sh)
+    result:setViewport(x, y, width, height, sw or width, sh or height)
   end
   
   return result

--- a/common/engine/Stack.lua
+++ b/common/engine/Stack.lua
@@ -255,10 +255,10 @@ Stack =
 
     s.warningsTriggered = {}
 
-    s.multi_prestopQuad = GraphicsUtil:newRecycledQuad(0, 0, s.theme.images.IMG_multibar_prestop_bar:getWidth(), s.theme.images.IMG_multibar_prestop_bar:getHeight(), s.theme.images.IMG_multibar_prestop_bar:getWidth(), s.theme.images.IMG_multibar_prestop_bar:getHeight())
-    s.multi_stopQuad = GraphicsUtil:newRecycledQuad(0, 0, s.theme.images.IMG_multibar_stop_bar:getWidth(), s.theme.images.IMG_multibar_stop_bar:getHeight(), s.theme.images.IMG_multibar_stop_bar:getWidth(), s.theme.images.IMG_multibar_stop_bar:getHeight())
-    s.multi_shakeQuad = GraphicsUtil:newRecycledQuad(0, 0, s.theme.images.IMG_multibar_shake_bar:getWidth(), s.theme.images.IMG_multibar_shake_bar:getHeight(), s.theme.images.IMG_multibar_shake_bar:getWidth(), s.theme.images.IMG_multibar_shake_bar:getHeight())
-    s.multiBarFrameCount = s:calculateMultibarFrameCount()
+    s:createSignal("matched")
+    s:createSignal("garbageLanded")
+
+    s:initializeGraphics()
   end,
   StackBase
 )
@@ -2011,11 +2011,11 @@ function Stack.onGarbageLand(self, panel)
       -- to prevent from running this code dozens of time for the same garbage block
       -- all panels of a garbage block have the same id + shake time
       self.garbageLandedThisFrame[#self.garbageLandedThisFrame+1] = panel.garbageId
+      self:emitSignal("garbageLanded", self, panel.shake_time)
     end
 
     -- whether we ran through it or not, the panel should lose its shake time
     panel.shake_time = nil
-    self:emitSignal("hurt", "hurt")
   end
 end
 

--- a/common/engine/StackBase.lua
+++ b/common/engine/StackBase.lua
@@ -26,8 +26,6 @@ local StackBase = class(function(self, args)
   self.game_over_clock = -1 -- the exact clock frame the player lost, -1 while alive
   Signal.turnIntoEmitter(self)
   self:createSignal("dangerMusicChanged")
-  self:createSignal("hurt")
-  self:createSignal("attackSent")
 
   -- rollback
   self.rollbackCopies = {}
@@ -40,7 +38,8 @@ local StackBase = class(function(self, args)
   self.gfxScale = 3
   self.canvas = love.graphics.newCanvas(104 * self.gfxScale, 204 * self.gfxScale, {dpiscale = GAME:newCanvasSnappedScale()})
   self.portraitFade = config.portrait_darkness / 100 -- will be set back to 0 if count down happens
-  self.healthQuad = GraphicsUtil:newRecycledQuad(0, 0, themes[config.theme].images.IMG_healthbar:getWidth(), themes[config.theme].images.IMG_healthbar:getHeight(), themes[config.theme].images.IMG_healthbar:getWidth(), themes[config.theme].images.IMG_healthbar:getHeight())
+  local imgWidth, imgHeight = themes[config.theme].images.IMG_healthbar:getDimensions()
+  self.healthQuad = GraphicsUtil:newRecycledQuad(0, 0, imgWidth, imgHeight, imgWidth, imgHeight)
 end)
 
 -- Provides the X origin to draw an element of the stack
@@ -407,6 +406,10 @@ end
 
 function StackBase:runGameOver()
   error("did not implement runGameOver")
+end
+
+function StackBase:initializeGraphics()
+  -- overwrite this function to add extra initialization
 end
 
 return StackBase

--- a/common/engine/checkMatches.lua
+++ b/common/engine/checkMatches.lua
@@ -135,11 +135,11 @@ function Stack:checkMatches()
     local preStopTime = frameConstants.FLASH + frameConstants.FACE + frameConstants.POP * (comboSize + garbagePanelCountOnScreen)
     self.pre_stop_time = math.max(self.pre_stop_time, preStopTime)
     self:awardStopTime(isChainLink, comboSize)
+    self:emitSignal("matched", self, attackGfxOrigin, isChainLink, comboSize, metalCount, #garbagePanels)
 
     if isChainLink or comboSize > 3 or metalCount > 0 then
       self:pushGarbage(attackGfxOrigin, isChainLink, comboSize, metalCount)
       self:queueAttackSoundEffect(isChainLink, self.chain_counter, comboSize, metalCount)
-      self:emitSignal("attackSent", "attack")
     end
 
     self.analytic:register_destroyed_panels(comboSize)


### PR DESCRIPTION
Quite some changes to how things are glued together here.
Overall the code was too specific to battle animations. And still is because while reviewing I realized that I actually want to change a lot more than I originally thought, hence the delays. I still didn't change a lot of things here but I felt overwhelmed trying to get everything at once done so here is part one with things I'm quite sure how to do, at least as an intermediary working state to build the next one on.

First of all the signals are meant to allow hooking in with any type of extra graphic or analytic code so naming the signals things like "hurt" are too specific to the battleAnimations.
I have changed the "attackSent" signal to a more generic "matched" signal that is always sent, not just if the match also produces garbage.
To compensate it includes a load of arguments to provide further information about the match so that code that hooks in here has a lot more detailed information to do stuff with. In particular I would like analytics to use this later rather than being hard-coded because analytics are not part of the engine functionality.
Matching is also specific to real stacks so I moved the signal creation from StackBase to Stack.
I realize that this "breaks" attack animations for challenge mode right now but given that challenge mode does not have the same interactions as real stacks I think that is ok for now. I would prefer to define a good set of signals for Stack now and check later if we can integrate SimulatedStacks.
Similarly, "hurt" to "garbageLanded", the concept of garbage landing on SimulatedStacks is just too different to include for now imo.